### PR TITLE
Add a testdrive service and test for Loki

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -225,6 +225,10 @@ Kafka configuration option use when connecting or performing operations. For exa
 
 Schema registry URL [default: http://localhost:8081]
 
+#### `--loki-addr <URL>`
+
+Loki URL [default: http://localhost:3100]
+
 ## Resource sharing and reuse across tests
 
 By default, `testdrive` will clean up the environment and Mz prior to running each test. In certain situations, two or more testdrive invocations need to run consequtively while being able to operate on the same database objects. The options below help to ensure successful cooperation.
@@ -470,6 +474,8 @@ The temporary directory to use. If no ```--temp-dir``` option is specified, it w
 #### `testdrive.materialized-addr`
 
 #### `testdrive.materialized-user`
+
+#### `testdrive.loki-addr`
 
 ## Accessing the environment variables
 
@@ -763,6 +769,12 @@ The test will fail unless the HTTP status code of the response is in the 200 ran
 #### `$ schema-registry-wait-schema schema=...`
 
 Block the test until the specified schema has been defined at the schema registry. This is used to fortify tests that expect an external party, e.g. Debezium to  upload a particular schema.
+
+## Actions on Loki
+
+#### `$ loki-ingest label1=... label2=... ...`
+
+Send log entries to Loki with the given label/value pairs.
 
 ## Actions with `psql`
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -691,3 +691,19 @@ class Kgen(Service):
                 "entrypoint": entrypoint,
             },
         )
+
+
+class Loki(Service):
+    def __init__(
+        self,
+        name: str = "loki",
+        image: str = "grafana/loki",
+        port: int = 3100,
+    ) -> None:
+        super().__init__(
+            name=name,
+            config={
+                "image": image,
+                "ports": [port],
+            },
+        )

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -544,6 +544,7 @@ class Testdrive(Service):
         volume_workdir: str = ".:/workdir",
         propagate_uid_gid: bool = True,
         forward_buildkite_shard: bool = False,
+        loki_addr: Optional[str] = None,
     ) -> None:
         if environment is None:
             environment = [
@@ -581,6 +582,9 @@ class Testdrive(Service):
             entrypoint.append("--no-reset")
 
         entrypoint.append(f"--default-timeout={default_timeout}")
+
+        if loki_addr:
+            entrypoint.append(f"--loki-addr={loki_addr}")
 
         if kafka_default_partitions:
             entrypoint.append(f"--kafka-default-partitions={kafka_default_partitions}")

--- a/src/testdrive/src/action/loki.rs
+++ b/src/testdrive/src/action/loki.rs
@@ -1,0 +1,124 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{collections::HashMap, time::Duration};
+
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use chrono::Utc;
+use mz_ore::retry::Retry;
+use serde::Serialize;
+use url::Url;
+
+use crate::action::{Action, ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+pub struct IngestAction {
+    /// Labels to be added to the ingested lines.
+    labels: HashMap<String, String>,
+    /// The lines to be ingested.
+    lines: Vec<String>,
+}
+
+pub fn build_ingest(cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Error> {
+    let labels = cmd.args.into_iter().collect();
+    Ok(IngestAction {
+        labels,
+        lines: cmd.input,
+    })
+}
+
+#[async_trait]
+impl Action for IngestAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
+        state
+            .loki_client
+            .push_logs(&self.labels, &self.lines)
+            .await?;
+        Ok(ControlFlow::Continue)
+    }
+}
+
+pub struct Client {
+    url: Url,
+    client: reqwest::Client,
+    timeout: Duration,
+}
+
+impl Client {
+    pub(super) fn new(url: Url, timeout: Duration) -> Self {
+        Self {
+            url,
+            client: reqwest::Client::new(),
+            timeout,
+        }
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    async fn push_logs(
+        &self,
+        labels: &HashMap<String, String>,
+        lines: &[String],
+    ) -> Result<(), anyhow::Error> {
+        let ts = Utc::now().timestamp_nanos().to_string();
+        let ts_str = ts.as_str();
+        let values: Vec<_> = lines
+            .iter()
+            .map(move |line| [ts_str, line.as_str()])
+            .collect();
+        let body = LokiApiV1Push {
+            streams: vec![Stream {
+                stream: &labels,
+                values: &values,
+            }],
+        };
+        let mut url = self.url.clone();
+        url.path_segments_mut()
+            .map_err(|_| anyhow!("invalid Loki URL"))?
+            .pop_if_empty()
+            .push("loki")
+            .push("api")
+            .push("v1")
+            .push("push");
+        Retry::default()
+            .max_duration(self.timeout)
+            .retry_async(|_| async {
+                self.client
+                    .post(url.clone())
+                    .json(&body)
+                    .send()
+                    .await
+                    .context("connecting to Loki")?
+                    .error_for_status()
+                    .context("Loki HTTP error")
+            })
+            .await
+            .context("sending Loki records")
+            // Drop the response, we don't care about it.
+            .map(|_| ())
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct LokiApiV1Push<'a> {
+    streams: Vec<Stream<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct Stream<'a> {
+    stream: &'a HashMap<String, String>,
+    values: &'a [[&'a str; 2]],
+}

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -167,6 +167,11 @@ struct Args {
     /// Cannot be specified if --aws-region is specified.
     #[clap(long, conflicts_with = "aws-region", value_name = "URL")]
     aws_endpoint: Option<Uri>,
+
+    // === Loki options. ===
+    /// Address of the Loki server that testdrive will interact with.
+    #[clap(long, value_name = "URL", default_value = "http://localhost:3100")]
+    loki_addr: Url,
 }
 
 #[tokio::main]
@@ -278,6 +283,9 @@ async fn main() {
         // === AWS options. ===
         aws_config,
         aws_account,
+
+        // === Loki options. ===
+        loki_addr: args.loki_addr,
     };
 
     // Build the list of files to test.

--- a/test/loki/loki.td
+++ b/test/loki/loki.td
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# The raw source that brings in data as a single text column containing JSON
+> CREATE SOURCE loki_system_logs_raw
+  FROM LOKI
+  ADDRESS 'http://loki:3100'
+  QUERY '{job="varlogs"}'
+  FORMAT TEXT;
+
+# Extract the JSON fields
+> CREATE VIEW loki_system_logs AS
+  SELECT
+    val->>'text' AS text,
+    val->'labels' AS labels
+  FROM (SELECT text::jsonb AS val FROM loki_system_logs_raw);
+
+# Create a materialized aggregation
+> CREATE MATERIALIZED VIEW logs_by_filename AS
+  SELECT labels->'filename', COUNT(*) FROM loki_system_logs GROUP BY labels->'filename';
+
+# See the data change
+> SELECT COUNT(*) > 0 FROM logs_by_filename ;
+true
+
+# Test that the volatility bit is set correctly.
+# > SELECT name, volatility FROM mz_sources WHERE name = 'market_orders_raw'
+# market_orders_raw   volatile
+# > SELECT name, volatility from mz_views WHERE name = 'avg_bid'
+# avg_bid   volatile
+# > CREATE MATERIALIZED VIEW nonvol AS SELECT 1
+# > SELECT name, volatility from mz_views WHERE name = 'nonvol'
+# nonvol   nonvolatile
+# > CREATE MATERIALIZED VIEW depends_vol_nonvol AS SELECT * FROM nonvol, avg_bid
+# > SELECT name, volatility from mz_views WHERE name = 'depends_vol_nonvol'
+# depends_vol_nonvol   volatile
+# $ file-append path=test
+# ignored
+# > CREATE MATERIALIZED SOURCE file_src FROM FILE '${testdrive.temp-dir}/test' FORMAT BYTES
+# > SELECT name, volatility FROM mz_sources WHERE name = 'file_src'
+# file_src  unknown
+# > CREATE MATERIALIZED VIEW depends_nonvol_unknown AS SELECT * FROM nonvol, file_src
+# > SELECT name, volatility from mz_views WHERE name = 'depends_nonvol_unknown'
+# depends_nonvol_unknown   unknown
+# > CREATE MATERIALIZED VIEW depends_vol_unknown AS SELECT * FROM avg_bid, file_src
+# > SELECT name, volatility from mz_views WHERE name = 'depends_vol_unknown'
+# depends_vol_unknown   volatile
+
+

--- a/test/loki/loki.td
+++ b/test/loki/loki.td
@@ -7,12 +7,25 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ loki-ingest job=foo node=node1
+first line
+second line
+
+$ loki-ingest job=bar node=node1
+first line
+
+$ loki-ingest job=foo node=node2
+first line
+
+$ loki-ingest job=bar node=node2
+first line
+second line
 
 # The raw source that brings in data as a single text column containing JSON
 > CREATE SOURCE loki_system_logs_raw
   FROM LOKI
-  ADDRESS 'http://loki:3100'
-  QUERY '{job="varlogs"}'
+  ADDRESS '${testdrive.loki-addr}'
+  QUERY '{job="foo"}'
   FORMAT TEXT;
 
 # Extract the JSON fields
@@ -24,11 +37,20 @@
 
 # Create a materialized aggregation
 > CREATE MATERIALIZED VIEW logs_by_filename AS
-  SELECT labels->'filename', COUNT(*) FROM loki_system_logs GROUP BY labels->'filename';
+  SELECT labels->>'job' AS job,
+    labels->>'node' AS node,
+    COUNT(*) AS n FROM loki_system_logs
+  GROUP BY labels->>'job', labels->>'node';
+
+> SELECT n FROM logs_by_filename WHERE job = 'foo' AND node = 'node1';
+2
+
+$ loki-ingest job=foo node=node1
+another line
 
 # See the data change
-> SELECT COUNT(*) > 0 FROM logs_by_filename ;
-true
+> SELECT n FROM logs_by_filename WHERE job = 'foo' AND node = 'node1';
+3
 
 # Test that the volatility bit is set correctly.
 # > SELECT name, volatility FROM mz_sources WHERE name = 'market_orders_raw'

--- a/test/loki/mzcompose
+++ b/test/loki/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/loki/mzcompose.py
+++ b/test/loki/mzcompose.py
@@ -26,8 +26,11 @@ def workflow_default(c: Composition) -> None:
 
     This workflow just runs all the other ones
     """
-    c.start_and_wait_for_tcp(services=["loki"])
 
-    c.up("materialized")
-    c.wait_for_materialized("materialized")
-    c.run("testdrive-svc", "loki.td")
+    testdrive = Testdrive(loki_addr="http://loki:3100")
+
+    with c.override(testdrive):
+        c.start_and_wait_for_tcp(services=["loki"])
+        c.up("materialized")
+        c.wait_for_materialized("materialized")
+        c.run("testdrive-svc", "loki.td")

--- a/test/loki/mzcompose.py
+++ b/test/loki/mzcompose.py
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import (
+    Loki,
+    Materialized,
+    Testdrive,
+)
+
+SERVICES = [
+    Loki(),
+    Materialized(),
+    Testdrive(),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    """All mzcompose files should contain a default workflow
+
+    This workflow just runs all the other ones
+    """
+    c.start_and_wait_for_tcp(services=["loki"])
+
+    c.up("materialized")
+    c.wait_for_materialized("materialized")
+    c.run("testdrive-svc", "loki.td")


### PR DESCRIPTION
This adds a super simple testdrive test for Loki which attempts to
connect to a Loki server (created in Docker by testdrive), create a
source, create some simple downstream (materialized) views, and assert
that some data exists.

Run this using `./mzcompose --dev run default` from the `test/loki`
directory.

Currently this test fails (naturally!) since we don't parse the SQL
correctly yet.