### PR TITLE
Add SQL parsing and plumbing for Loki source creation

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1215,6 +1215,7 @@ pub mod sources {
         S3(S3SourceConnector),
         Postgres(PostgresSourceConnector),
         PubNub(PubNubSourceConnector),
+        Loki(LokiSourceConnector),
     }
 
     impl ExternalSourceConnector {
@@ -1282,6 +1283,7 @@ pub mod sources {
                     };
                     columns
                 }
+                Self::Loki(_) => vec![],
                 Self::Postgres(_) => vec![],
                 Self::PubNub(_) => vec![],
             }
@@ -1295,6 +1297,7 @@ pub mod sources {
                 ExternalSourceConnector::File(_) => Some("mz_line_no"),
                 ExternalSourceConnector::AvroOcf(_) => Some("mz_obj_no"),
                 ExternalSourceConnector::S3(_) => Some("mz_record"),
+                ExternalSourceConnector::Loki(_) => None,
                 ExternalSourceConnector::Postgres(_) => None,
                 ExternalSourceConnector::PubNub(_) => None,
             }
@@ -1340,9 +1343,9 @@ pub mod sources {
                         Vec::new()
                     }
                 }
-                ExternalSourceConnector::Postgres(_) | ExternalSourceConnector::PubNub(_) => {
-                    Vec::new()
-                }
+                ExternalSourceConnector::Loki(_)
+                | ExternalSourceConnector::Postgres(_)
+                | ExternalSourceConnector::PubNub(_) => Vec::new(),
             }
         }
 
@@ -1354,6 +1357,7 @@ pub mod sources {
                 ExternalSourceConnector::File(_) => "file",
                 ExternalSourceConnector::AvroOcf(_) => "avro-ocf",
                 ExternalSourceConnector::S3(_) => "s3",
+                ExternalSourceConnector::Loki(_) => "loki",
                 ExternalSourceConnector::Postgres(_) => "postgres",
                 ExternalSourceConnector::PubNub(_) => "pubnub",
             }
@@ -1375,6 +1379,7 @@ pub mod sources {
                 ExternalSourceConnector::S3(_) => None,
                 ExternalSourceConnector::Postgres(_) => None,
                 ExternalSourceConnector::PubNub(_) => None,
+                ExternalSourceConnector::Loki(_) => None,
             }
         }
 
@@ -1386,6 +1391,7 @@ pub mod sources {
                 ExternalSourceConnector::Kafka(_)
                 | ExternalSourceConnector::Kinesis(_)
                 | ExternalSourceConnector::File(_)
+                | ExternalSourceConnector::Loki(_)
                 | ExternalSourceConnector::AvroOcf(_)
                 | ExternalSourceConnector::PubNub(_) => false,
             }
@@ -1416,6 +1422,12 @@ pub mod sources {
     pub struct PubNubSourceConnector {
         pub subscribe_key: String,
         pub channel: String,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct LokiSourceConnector {
+        pub address: String,
+        pub query: String,
     }
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -119,7 +119,9 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                     Some(rt_default)
                 }
                 ExternalSourceConnector::Kafka(_) => Some(rt_default),
-                ExternalSourceConnector::Postgres(_) | ExternalSourceConnector::PubNub(_) => None,
+                ExternalSourceConnector::Loki(_)
+                | ExternalSourceConnector::Postgres(_)
+                | ExternalSourceConnector::PubNub(_) => None,
             }
         } else {
             debug!(

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -83,6 +83,7 @@ pub use file::FileReadStyle;
 pub use file::FileSourceReader;
 pub use kafka::KafkaSourceReader;
 pub use kinesis::KinesisSourceReader;
+pub use loki::LokiSourceReader;
 pub use postgres::PostgresSourceReader;
 pub use pubnub::PubNubSourceReader;
 pub use s3::S3SourceReader;

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -494,6 +494,12 @@ pub enum CreateSourceConnector {
         /// The PubNub channel to subscribe to
         channel: String,
     },
+    Loki {
+        /// The address of the Loki HTTP endpoint.
+        address: String,
+        /// The LogQL query to issue to Loki.
+        query: String,
+    },
 }
 
 impl AstDisplay for CreateSourceConnector {
@@ -568,6 +574,13 @@ impl AstDisplay for CreateSourceConnector {
                 f.write_str(&display::escape_single_quote_string(subscribe_key));
                 f.write_str("' CHANNEL '");
                 f.write_str(&display::escape_single_quote_string(channel));
+                f.write_str("'");
+            }
+            CreateSourceConnector::Loki { address, query } => {
+                f.write_str("LOKI ADDRESS '");
+                f.write_str(&display::escape_single_quote_string(address));
+                f.write_str("' QUERY '");
+                f.write_str(&display::escape_single_quote_string(query));
                 f.write_str("'");
             }
         }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -23,6 +23,7 @@
 #
 # For details on the code that is generated, see keywords.rs.
 
+Address
 All
 Alter
 And
@@ -161,6 +162,7 @@ List
 Local
 Log
 Login
+Loki
 Map
 Matching
 Materialize

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2010,7 +2010,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector, ParserError> {
-        match self.expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
+        match self
+            .expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB, LOKI])?
+        {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
                 let subscribe_key = self.parse_literal_string()?;
@@ -2120,6 +2122,13 @@ impl<'a> Parser<'a> {
                     pattern,
                     compression,
                 })
+            }
+            LOKI => {
+                self.expect_keyword(ADDRESS)?;
+                let address = self.parse_literal_string()?;
+                self.expect_keyword(QUERY)?;
+                let query = self.parse_literal_string()?;
+                Ok(CreateSourceConnector::Loki { address, query })
             }
             _ => unreachable!(),
         }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -38,9 +38,9 @@ use mz_dataflow_types::{
         },
         provide_default_metadata, DebeziumDedupProjection, DebeziumEnvelope, DebeziumMode,
         DebeziumSourceProjection, ExternalSourceConnector, FileSourceConnector, IncludedColumnPos,
-        KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, PostgresSourceConnector,
-        PubNubSourceConnector, S3SourceConnector, SourceConnector, SourceEnvelope, Timeline,
-        UnplannedSourceEnvelope, UpsertStyle,
+        KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, LokiSourceConnector,
+        PostgresSourceConnector, PubNubSourceConnector, S3SourceConnector, SourceConnector,
+        SourceEnvelope, Timeline, UnplannedSourceEnvelope, UpsertStyle,
     },
 };
 use mz_expr::GlobalId;
@@ -532,6 +532,17 @@ pub fn plan_create_source(
             let connector = ExternalSourceConnector::PubNub(PubNubSourceConnector {
                 subscribe_key: subscribe_key.clone(),
                 channel: channel.clone(),
+            });
+            (connector, SourceDataEncoding::Single(DataEncoding::Text))
+        }
+        CreateSourceConnector::Loki { address, query } => {
+            match format {
+                CreateSourceFormat::None | CreateSourceFormat::Bare(Format::Text) => (),
+                _ => bail!("CREATE SOURCE ... LOKI must specify FORMAT TEXT"),
+            }
+            let connector = ExternalSourceConnector::Loki(LokiSourceConnector {
+                address: address.clone(),
+                query: query.clone(),
             });
             (connector, SourceDataEncoding::Single(DataEncoding::Text))
         }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -203,6 +203,9 @@ pub fn purify(
                     let _ = mz_postgres_util::publication_info(&conn, &publication).await?;
                 }
                 CreateSourceConnector::PubNub { .. } => (),
+                CreateSourceConnector::Loki { .. } => {
+                    // TODO(bsull): do we need to do anything here?
+                }
             }
 
             purify_source_format(


### PR DESCRIPTION
This adds the new keywords to the SQL parser for the Loki source, and
connects everything up so that a Loki source is created by the CREATE
SOURCE query.

This is almost all copy+pasted from the PubNub source (or just driven by
enum exhausiveness-checking). Some of the values may need changing soon
as the source develops.

The CREATE SOURCE command looks like this:

    CREATE SOURCE src_name
    FROM LOKI
    ADDRESS 'http://loki'
    QUERY '{job="varlogs"}'
    FORMAT TEXT;

Note that the only two source parameters here are 'address' and 'query',
which differs from the three commands in the constructor of the
`LokiSourceReader`; these may need changing at a later date.

The Loki source also only supports FORMAT TEXT for now, on the
assumption that we'll always be fetching JSON from Loki.
