### PR TITLE
Reduce the number of intermediate copies in the Loki source

### DIFF
--- a/src/dataflow/src/source/loki.rs
+++ b/src/dataflow/src/source/loki.rs
@@ -4,16 +4,13 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use anyhow::Context;
 use async_trait::async_trait;
-use futures::future::TryFutureExt;
-use futures::stream::{self, StreamExt};
-use serde::{Deserialize, Serialize};
-use tokio_stream::wrappers::IntervalStream;
-use tracing::warn;
-
 use mz_dataflow_types::SourceErrorDetails;
 use mz_expr::SourceInstanceId;
 use mz_repr::{Datum, Row};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::source::{SimpleSource, SourceError, Timestamper};
 
@@ -37,60 +34,51 @@ impl LokiConnectionInfo {
     pub fn from_env() -> LokiConnectionInfo {
         let user = env::var("LOKI_USERNAME").ok();
         let pw = env::var("LOKI_PASSWORD").ok();
-        let endpoint = env::var("LOKI_ADDR").unwrap_or("".to_string());
-        return LokiConnectionInfo { user, pw, endpoint };
+        let endpoint = env::var("LOKI_ADDR").unwrap_or_else(|_| "".to_string());
+        LokiConnectionInfo { user, pw, endpoint }
     }
 
     pub fn with_user(mut self, user: Option<String>) -> LokiConnectionInfo {
         self.user = user;
-        return self;
+        self
     }
 
     pub fn with_password(mut self, password: Option<String>) -> LokiConnectionInfo {
         self.pw = password;
-        return self;
+        self
     }
 
     pub fn with_endpoint(mut self, address: Option<String>) -> LokiConnectionInfo {
         if let Some(address) = address {
             self.endpoint = address;
-            return self;
-        } else {
-            return self;
         }
+        self
     }
 }
 
 impl LokiSourceReader {
     pub fn new(
         source_id: SourceInstanceId,
-        conn_info: LokiConnectionInfo,
+        mut conn_info: LokiConnectionInfo,
         query: String,
     ) -> LokiSourceReader {
+        conn_info.endpoint = format!("{}/loki/api/v1/query_range", conn_info.endpoint);
         Self {
             source_id,
             conn_info,
             batch_window: Duration::from_secs(10),
-            query: query,
+            query,
             client: reqwest::Client::new(),
         }
     }
 
-    async fn query(
-        &self,
-        start: u128,
-        end: u128,
-        query: String,
-    ) -> Result<reqwest::Response, reqwest::Error> {
-        let mut r = self.client.get(format!(
-            "{}/loki/api/v1/query_range",
-            self.conn_info.endpoint
-        ));
-
+    #[tracing::instrument(skip(self), level = "trace")]
+    async fn query(&self, start: u128, end: u128) -> Result<reqwest::Response, reqwest::Error> {
+        let mut r = self.client.get(&self.conn_info.endpoint);
         if let Some(ref user) = self.conn_info.user {
             r = r.basic_auth(user, self.conn_info.pw.clone());
         };
-        r.query(&[("query", query)])
+        r.query(&[("query", &self.query)])
             .query(&[("start", format!("{}", start))])
             .query(&[("end", format!("{}", end))])
             .query(&[("direction", "forward")])
@@ -98,100 +86,113 @@ impl LokiSourceReader {
             .await
     }
 
-    fn new_stream<'a>(
-        &'a self,
-    ) -> impl stream::Stream<Item = Result<QueryResult, reqwest::Error>> + 'a {
-        let polls = IntervalStream::new(tokio::time::interval(self.batch_window));
-
-        polls.then(move |_tick| {
-            let end = SystemTime::now();
-            let start = end - self.batch_window;
-
-            self.query(
-                start
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Start must be after epoch.")
-                    .as_nanos(),
-                end.duration_since(UNIX_EPOCH)
-                    .expect("End must be after epoch.")
-                    .as_nanos(),
-                self.query.clone(),
+    #[tracing::instrument(skip(self), level = "trace")]
+    async fn tick(&self) -> Result<Vec<String>, anyhow::Error> {
+        let end = SystemTime::now();
+        let start = end - self.batch_window;
+        let response = self
+            .query(
+                start.duration_since(UNIX_EPOCH).unwrap().as_nanos(),
+                end.duration_since(UNIX_EPOCH).unwrap().as_nanos(),
             )
-            .and_then(|resp| resp.json::<QueryResult>())
-        })
+            .await
+            .context("Connection error")?
+            .error_for_status()
+            .context("HTTP error")?
+            .bytes()
+            .await
+            .context("Download error")?;
+        let result: QueryResult = serde_json::from_slice(&response).context("Deserialize error")?;
+        let Data::Streams(streams) = result.data;
+
+        #[derive(Debug, Serialize)]
+        struct LokiRow<'a> {
+            timestamp: &'a str,
+            line: &'a str,
+            labels: &'a HashMap<&'a str, &'a str>,
+        }
+
+        // TODO(bsull): we could get rid of this intermediate Vec if we handled the timestamp sending
+        // in this function instead, but for now it's quite nice to be able to see the resulting JSON
+        // in a test.
+        let lines: Vec<String> = streams
+            .iter()
+            .flat_map(|s| {
+                s.values.iter().map(|v| {
+                    serde_json::to_string(&LokiRow {
+                        timestamp: v.ts,
+                        line: v.line,
+                        labels: &s.labels,
+                    })
+                    .expect("Loki data should be valid JSON")
+                })
+            })
+            .collect();
+        Ok(lines)
     }
 }
 
 #[async_trait]
 impl SimpleSource for LokiSourceReader {
     async fn start(mut self, timestamper: &Timestamper) -> Result<(), SourceError> {
-        let stream = self.new_stream();
-        tokio::pin!(stream);
-
-        while let Some(entry) = stream.next().await {
-            match entry {
-                Ok(result) => {
-                    let Data::Streams(streams) = result.data;
-
-                    #[derive(Debug, Serialize)]
-                    struct LokiRow<'a> {
-                        line: &'a str,
-                        labels: &'a HashMap<String, String>,
-                    }
-
-                    let lines: Vec<String> = streams
-                        .iter()
-                        .flat_map(|s| {
-                            s.values.iter().map(|v| {
-                                serde_json::to_string(&LokiRow {
-                                    line: &v.line,
-                                    labels: &s.labels,
-                                })
-                                .unwrap()
-                            })
-                        })
-                        .collect();
-
+        let mut interval = tokio::time::interval(self.batch_window);
+        loop {
+            interval.tick().await;
+            match self.tick().await {
+                Ok(lines) => {
+                    let tx = timestamper.start_tx().await;
                     for line in lines {
-                        let row = Row::pack_slice(&[Datum::String(&line)]);
-
-                        timestamper.insert(row).await.map_err(|e| SourceError {
-                            source_id: self.source_id.clone(),
-                            error: SourceErrorDetails::FileIO(e.to_string()),
-                        })?;
+                        tx.insert(Row::pack_slice(&[Datum::String(&line)]))
+                            .await
+                            .map_err(|e| {
+                                SourceError::new(
+                                    self.source_id,
+                                    SourceErrorDetails::Persistence(e.to_string()),
+                                )
+                            })?;
                     }
+                    Ok(())
                 }
-                Err(e) => warn!("Loki error: {:?}", e),
-            }
+                Err(e) => {
+                    warn!("Loki error: {}", e);
+                    Err(SourceError::new(
+                        self.source_id,
+                        SourceErrorDetails::Persistence(e.to_string()),
+                    ))
+                }
+            }?;
         }
-        Ok(())
     }
 }
 
 #[derive(Debug, Deserialize)]
-struct QueryResult {
-    status: String,
-    data: Data,
+struct QueryResult<'a> {
+    status: &'a str,
+    #[serde(borrow)]
+    data: Data<'a>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "resultType", content = "result")]
-enum Data {
-    #[serde(rename = "streams")]
-    Streams(Vec<Stream>),
+enum Data<'a> {
+    #[serde(borrow, rename = "streams")]
+    Streams(Vec<Stream<'a>>),
 }
 
 #[derive(Debug, Deserialize)]
-struct Stream {
-    #[serde(rename = "stream")]
-    labels: HashMap<String, String>,
-    values: Vec<LogEntry>,
+struct Stream<'a> {
+    #[serde(borrow, rename = "stream")]
+    labels: HashMap<&'a str, &'a str>,
+    #[serde(borrow)]
+    values: Vec<LogEntry<'a>>,
 }
 
 #[derive(Debug, Deserialize)]
-struct LogEntry {
-    ts: String,
-    line: String,
+struct LogEntry<'a> {
+    #[serde(borrow)]
+    ts: &'a str,
+    #[serde(borrow)]
+    line: &'a str,
 }
 
 #[cfg(test)]
@@ -220,10 +221,13 @@ mod test {
             "{job=\"systemd-journal\"}".to_owned(),
         );
 
-        let fut = loki.new_stream().take(5);
-        fut.for_each(|data| async move {
-            println!("{:?}", data);
-        })
-        .await;
+        for _ in 0..5 {
+            println!("{:?}", loki.tick().await);
+        }
+        // let fut = loki.new_stream().take(5);
+        // fut.for_each(|data| async move {
+        //     println!("{:?}", data);
+        // })
+        // .await;
     }
 }


### PR DESCRIPTION
I'll admit this was mostly for my own benefit, I just wanted to see if it was possible to do without much allocation! We could actually get rid of the intermediate `Vec<String>` too but for now it's quite nice to see the output of `LokiSourceReader::tick()`.

This will probably conflict with #9 so I'll rebase after that's merged.